### PR TITLE
Capacitor: improve UNUserNotificationCenterDelegate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 Batch Cordova Plugin
 
+## Upcoming
+
+**iOS**
+
+* Fix `BatchBridgeNotificationCenterDelegate.automaticallyRegister` not being honored.
+* Add compatibility for Capacitor 4.6: Batch's delegate now tries to register itself at a later time to keep compatibility with Capacitor's push plugins and Batch's features at the same time.
+
 ## 5.3.0
 
 **Plugin**

--- a/dist/src/ios/interop/BatchBridgeNotificationCenterDelegate.m
+++ b/dist/src/ios/interop/BatchBridgeNotificationCenterDelegate.m
@@ -22,7 +22,9 @@ static BOOL _batBridgeNotifDelegateShouldAutomaticallyRegister = true;
 }
 
 + (void)applicationFinishedLaunching:(NSNotification*)notification {
-    [BatchBridgeNotificationCenterDelegate registerAsDelegate];
+    if ([BatchBridgeNotificationCenterDelegate automaticallyRegister]) {
+        [BatchBridgeNotificationCenterDelegate registerAsDelegate];
+    }
 }
 
 + (BatchBridgeNotificationCenterDelegate *)sharedInstance


### PR DESCRIPTION
Fix a couple of issues with our UNUserNotificationCenterDelegate:
- It does not honor the "automaticallyRegister" config flag
- It used to work with Capacitor's, but they rewrote theirs and it is now registered way later. Handle that by reregistering it in pluginInitialize, which is the soonest we can without resorting to ugly hacks.

I have yet to test this in a project, so lets not merge this right away!

PS: One day we might want to migrate to a native capacitor plugin