### PR TITLE
Ionic: fix unusernotificationcenterdelegate infinite loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 Batch Cordova Plugin
 
+## 5.3.2
+
+**iOS**
+
+* Fix an issue where `BatchBridgeNotificationCenterDelegate`'s automatic setup might result in an infinite loop on notification open.
+
 ## 5.3.1
 
 **iOS**

--- a/dist/src/ios/interop/BatchBridgeNotificationCenterDelegate.m
+++ b/dist/src/ios/interop/BatchBridgeNotificationCenterDelegate.m
@@ -10,6 +10,7 @@
 {
     BOOL _isBatchReady;
     NSMutableArray<UNNotificationResponse*>* _enqueuedNotificationResponses;
+    __weak __nullable id<UNUserNotificationCenterDelegate> _previousDelegate;
 }
 
 static BOOL _batBridgeNotifDelegateShouldAutomaticallyRegister = true;
@@ -54,6 +55,22 @@ static BOOL _batBridgeNotifDelegateShouldAutomaticallyRegister = true;
 + (void)setAutomaticallyRegister:(BOOL)automaticallyRegister
 {
     _batBridgeNotifDelegateShouldAutomaticallyRegister = automaticallyRegister;
+}
+
+- (nullable id<UNUserNotificationCenterDelegate>)previousDelegate
+{
+    return _previousDelegate;
+}
+
+- (void)setPreviousDelegate:(nullable id<UNUserNotificationCenterDelegate>)delegate
+{
+    // Do not register ourserlves as previous delegate to avoid
+    // an infinite loop
+    if (delegate == self || [delegate isKindOfClass:[self class]]) {
+        _previousDelegate = nil;
+    } else {
+        _previousDelegate = delegate;
+    }
 }
 
 - (instancetype)init


### PR DESCRIPTION
Last patch introduced a regression for older Ionic versions where the app could end up in an infinite loop

This is because the delegate registered twice, and thus set itself at the "previous delegate"