### PR TITLE
Update default foreground notification behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 Batch Cordova Plugin
 
+## UPCOMING
+
+**iOS**
+* `BatchBridgeNotificationCenterDelegate` now defaults to showing foreground notifications.
+
+
 ## 6.0.0
 
 This is a major release, please see our [migration guide](https://doc.batch.com/cordova/migrations/5x-migration/) for more info on how to update your current Batch implementation.

--- a/dist/src/ios/interop/BatchBridgeNotificationCenterDelegate.h
+++ b/dist/src/ios/interop/BatchBridgeNotificationCenterDelegate.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)registerAsDelegate;
 
 /// Should iOS display notifications even if the app is in foreground?
-/// Default: false
+/// Default: true
 @property (assign) BOOL showForegroundNotifications;
 
 /// Should Batch use the chained delegate's completionHandler responses or force its own, while still calling the chained delegate.

--- a/dist/src/ios/interop/BatchBridgeNotificationCenterDelegate.m
+++ b/dist/src/ios/interop/BatchBridgeNotificationCenterDelegate.m
@@ -77,7 +77,7 @@ static BOOL _batBridgeNotifDelegateShouldAutomaticallyRegister = true;
 {
     self = [super init];
     if (self) {
-        _showForegroundNotifications = false;
+        _showForegroundNotifications = true;
         _shouldUseChainedCompletionHandlerResponse = true;
         _isBatchReady = false;
         _enqueuedNotificationResponses = [NSMutableArray new];


### PR DESCRIPTION
* `BatchBridgeNotificationCenterDelegate` now defaults to showing foreground notifications.

