### PR TITLE
Remove deprecated api registerForRemoteNotifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Batch Cordova Plugin
 - Added `setPhoneNumber` API to the `BatchProfileAttributeEditor` class. This requires to have a user identifier registered or to call the `identify` method beforehand.
 - Added `setSMSMarketingSubscription` API to the `BatchProfileAttributeEditor` class.
 
+**Push**
+- Removed deprecated API `registerForRemoteNotifications`. Please use `requestNotificationAuthorization` to request permission when needed, and `requestToken` at each app launch.
+
 ## 6.0.0
 
 This is a major release, please see our [migration guide](https://doc.batch.com/cordova/migrations/5x-migration/) for more info on how to update your current Batch implementation.

--- a/dist/src/android/interop/Action.java
+++ b/dist/src/android/interop/Action.java
@@ -21,7 +21,6 @@ public enum Action
     MESSAGING_SET_DO_NOT_DISTURB_ENABLED("messaging.setDoNotDisturbEnabled"),
     MESSAGING_SHOW_PENDING_MESSAGE("messaging.showPendingMessage"),
     PUSH_GET_LAST_KNOWN_TOKEN("push.getLastKnownPushToken"),
-    PUSH_REGISTER("push.register"),
     PUSH_SET_GCM_SENDER_ID("push.setGCMSenderID"),
     PUSH_CLEAR_BADGE("push.clearBadge"),
     PUSH_DISMISS_NOTIFICATIONS("push.dismissNotifications"),

--- a/dist/src/android/interop/Bridge.java
+++ b/dist/src/android/interop/Bridge.java
@@ -139,9 +139,6 @@ public class Bridge {
             case PUSH_DISMISS_NOTIFICATIONS:
                 dismissNotifications();
                 break;
-            case PUSH_REGISTER:
-                // iOS only, do nothing
-                return null;
             case PUSH_CLEAR_BADGE:
                 // iOS only, do nothing
                 return null;

--- a/dist/src/ios/interop/BatchBridge.m
+++ b/dist/src/ios/interop/BatchBridge.m
@@ -274,10 +274,6 @@ static dispatch_once_t onceToken;
     {
         // Do nothing
     }
-    else if ([action caseInsensitiveCompare:REGISTER_NOTIFS] == NSOrderedSame)
-    {
-        [BatchBridge registerForRemoteNotifications];
-    }
     else if ([action caseInsensitiveCompare:DISMISS_NOTIFS] == NSOrderedSame)
     {
         [BatchBridge dismissNotifications];
@@ -481,12 +477,6 @@ static dispatch_once_t onceToken;
 + (void)setNotificationTypes:(BatchNotificationType)type
 {
     [BatchPush setRemoteNotificationTypes:type];
-}
-
-+ (void)registerForRemoteNotifications
-{
-    [BatchPush requestNotificationAuthorization];
-    [BatchPush refreshToken];
 }
 
 + (void)clearBadge

--- a/dist/src/ios/interop/BatchBridgeShared.h
+++ b/dist/src/ios/interop/BatchBridgeShared.h
@@ -28,7 +28,6 @@ if (error == NULL) {\
 #define PUSH_REQUEST_AUTHORIZATION          @"push.requestAuthorization"
 #define PUSH_REQUEST_PROVISIONAL_AUTH       @"push.iOS.requestProvisionalAuthorization"
 
-#define REGISTER_NOTIFS                     @"push.register"
 #define DISMISS_NOTIFS                      @"push.dismissNotifications"
 #define CLEAR_BADGE                         @"push.clearBadge"
 

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -14,7 +14,6 @@ export enum Push {
   SetIOSShowForegroundNotifications = "push.setIOSShowForegroundNotifications",
   SetIOSNotifTypes = "push.setIOSNotifTypes",
   SetAndroidNotifTypes = "push.setAndroidNotifTypes",
-  Register = "push.register",
   DismissNotifications = "push.dismissNotifications",
   ClearBadge = "push.clearBadge",
   RefreshToken = "push.iOS.refreshToken",

--- a/src/batchStub.ts
+++ b/src/batchStub.ts
@@ -19,7 +19,6 @@ class PushStub implements BatchSDK.PushModule {
     this.iOSNotificationTypes = iOSNotificationTypes;
   }
 
-  public registerForRemoteNotifications() {}
   public refreshToken() {}
   public requestNotificationAuthorization() {}
   public requestProvisionalNotificationAuthorization() {}

--- a/src/modules/push.ts
+++ b/src/modules/push.ts
@@ -34,10 +34,6 @@ export class PushModule implements BatchSDK.PushModule {
     this.iOSNotificationTypes = iOSNotificationTypes;
   }
 
-  public registerForRemoteNotifications(): void {
-    sendToBridge(null, PushActions.Register, null);
-  }
-
   public refreshToken(): void {
     sendToBridge(null, PushActions.RefreshToken, null);
   }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -363,13 +363,6 @@ export declare namespace BatchSDK {
     iOSNotificationTypes: typeof iOSNotificationTypes;
 
     /**
-     * Ask iOS users if they want to accept push notifications. Required to be able to push users.
-     * No effect on Android.
-     * @deprecated Use requestNotificationAuthorization/requestProvisionalNotificationAuthorization and refreshToken
-     */
-    registerForRemoteNotifications(): void;
-
-    /**
      * Ask iOS to refresh the push token. If the app didn't prompt the user for consent yet, this will not be done.
      * You should call this at the start of your app, to make sure Batch always gets a valid token after app updates.
      */


### PR DESCRIPTION
**Push**
- Removed deprecated API `registerForRemoteNotifications`. Please use `requestNotificationAuthorization` to request permission when needed, and `requestToken` at each app launch.
